### PR TITLE
请升级org.eclipse.jetty.aggregate:jetty-all组件版本以解决1个安全漏洞

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1280,6 +1280,11 @@
                     </executions>
                     <dependencies>
                         <dependency>
+                            <groupId>org.eclipse.jetty.aggregate</groupId>
+                            <artifactId>jetty-all</artifactId>
+                            <version>9.4.50.v20221201</version>
+                        </dependency>
+                        <dependency>
                             <groupId>org.apache.storm</groupId>
                             <artifactId>storm-checkstyle</artifactId>
                             <version>${project.version}</version>


### PR DESCRIPTION
将 **org.eclipse.jetty.aggregate:jetty-all** 组件从7.6.0.v20120127 版本升级至 9.4.50.v20221201版本,
用于修复以下安全漏洞：


序号 | 漏洞编号 | 漏洞标题 | 漏洞级别
-- | -- | -- | --
1 | [MPS-2016-5010](https://www.oscs1024.com/hd/MPS-2016-5010) | Eclipse Jetty 信息泄露漏洞 | 高危
  |   |   |   


<br/>

_注意 ：此 PR 由您（或拥有此仓库权限的其他维护者）授权 [墨菲安全](https://www.murphysec.com) 打开_

了解更多：
- [如何快速修复代码安全问题](https://www.murphysec.com/docs/faqs/security-issues/how-to-quick-fixes.html)
